### PR TITLE
Add 3D Spline demo section

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@emailjs/browser": "^4.4.1",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@splinetool/react-spline": "^4.1.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.23.9",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
+import Spline from "@splinetool/react-spline/next";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -340,6 +341,14 @@ export default function Home() {
 
           </motion.div>
         </div>
+      </section>
+
+      {/* 3D Demo Section */}
+      <section className="relative w-full h-[600px]">
+        <Spline
+          scene="https://prod.spline.design/CpEDx75DIM1oGHaG/scene.splinecode"
+          className="absolute inset-0 w-full h-full"
+        />
       </section>
 
       {/* Artisanal Process Section */}


### PR DESCRIPTION
## Summary
- add `@splinetool/react-spline` dependency
- show interactive 3D animation after the hero section

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ab74fb6a88326a4c90fce75cac117