### PR TITLE
Improve greenhouse banners and enlarge carousel images

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -492,7 +492,7 @@ export default function Home() {
 
                   {/* Image Cover */}
                   <div className="mb-6 md:mb-8 relative">
-                    <div className="h-32 md:h-40 lg:h-48 rounded-2xl border-2 border-green-natural/40 relative overflow-hidden">
+                    <div className="h-48 md:h-56 lg:h-64 rounded-2xl border-2 border-green-natural/40 relative overflow-hidden">
                       <img
                         src="https://i.imgur.com/uwyysqy.png"
                         alt="Invernadero Estándar - Chanyman Greengarden"
@@ -574,7 +574,7 @@ export default function Home() {
 
                   {/* Image Cover */}
                   <div className="mb-6 md:mb-8 relative">
-                    <div className="h-32 md:h-40 lg:h-48 rounded-2xl border-2 border-green-natural/40 relative overflow-hidden">
+                    <div className="h-48 md:h-56 lg:h-64 rounded-2xl border-2 border-green-natural/40 relative overflow-hidden">
                       <img
                         src="https://i.imgur.com/1jtBCr3.jpeg"
                         alt="Invernadero Personalizado - Chanyman Greengarden"

--- a/src/components/ScrollingCarousel.tsx
+++ b/src/components/ScrollingCarousel.tsx
@@ -19,7 +19,7 @@ export default function ScrollingCarousel({ images, duration = 20, className }: 
         {duplicated.map((img, idx) => (
           <div
             key={idx}
-            className="flex-shrink-0 w-16 h-12 md:w-20 md:h-16 border border-green-natural/40 rounded-lg overflow-hidden"
+            className="flex-shrink-0 w-20 h-16 md:w-24 md:h-20 border border-green-natural/40 rounded-lg overflow-hidden"
           >
             <img src={img} alt={`imagen ${idx + 1}`} className="w-full h-full object-cover" />
           </div>


### PR DESCRIPTION
## Summary
- enlarge banner image height for Standard and Custom greenhouse cards
- slightly increase carousel thumbnail size for better preview

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689016710bbc8328a7b8fda3fba2ede3