### PR TITLE
Use single logo image in header and add favicon

### DIFF
--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="#ffffff" stroke-width="4">
+  <rect x="8" y="28" width="48" height="28" />
+  <polygon points="32,8 6,28 58,28" />
+  <line x1="32" y1="8" x2="32" y2="56" />
+</svg>

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none" stroke="#ffffff" stroke-width="4">
+  <rect x="8" y="28" width="48" height="28" />
+  <polygon points="32,8 6,28 58,28" />
+  <line x1="32" y1="8" x2="32" y2="56" />
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -17,6 +17,9 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Chanyman Greengarden - Invernaderos Artesanales de Calidad",
   description: "Descubre nuestros invernaderos artesanales con estructura de hierro y placas de policarbonato. Diseño elegante y funcional para tu jardín.",
+  icons: {
+    icon: "/favicon.svg",
+  },
 };
 
 export default function RootLayout({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -196,12 +196,12 @@ export default function Home() {
           className="flex items-center"
         >
           <div className="flex items-center space-x-3">
-            <div className="w-12 h-12 bg-green-natural rounded-xl flex items-center justify-center relative">
-              <Image src="https://i.imgur.com/eo3sva9.png" alt="Invernadero" width={24} height={24} />
-              <div className="absolute -bottom-1 -right-1 bg-white text-green-natural text-xs font-bold px-1 py-0.5 rounded text-[8px]">
-                CG
-              </div>
-            </div>
+            <Image
+              src="/logo.svg"
+              alt="Chanyman Greengarden"
+              width={48}
+              height={48}
+            />
             <div>
               <h1 className="text-2xl font-montserrat font-bold text-white">
                 Chanyman Greengarden


### PR DESCRIPTION
## Summary
- replace header logo composition with a single image
- register new favicon in metadata

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit`
- `npx next lint`


------
https://chatgpt.com/codex/tasks/task_e_6892a6004dd883289ae82e0fa1cdc814